### PR TITLE
Update JNA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.6.0</version>
+            <version>5.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.jai-imageio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.sourceforge.tess4j</groupId>
     <artifactId>tess4j</artifactId>
-    <version>4.5.3-PKWARE-SNAPSHOT</version>
+    <version>4.5.3-PKWARE</version>
     <packaging>jar</packaging>
 
     <name>Tess4J - Tesseract for Java</name>


### PR DESCRIPTION
I could not run tesseract 4.1.1 locally on my mac due to incompatible architecture. After spending a lot of time troubleshooting this issue, I discovered that the root cause was that JNA versions 5.6.0 and earlier were not capable with Mac Silicon. Upgrading to 5.7.0 resolved this issue.

The branch `release/4.5.3-PKWARE` is based on the `tess4j-4.5.3` tag (which corresponds to tesseract 4.1.1), with an added commit for preparing the next development version (`4.5.3-PKWARE-SNAPSHOT`).